### PR TITLE
Fix granular controls to rebuild chart in-place

### DIFF
--- a/script.js
+++ b/script.js
@@ -1420,36 +1420,14 @@ document.getElementById("more-granular").addEventListener("click", () => {
     restoreOriginalView();
     if (maxLevel < 20) { // Define an upper limit if necessary
         maxLevel++;
-        /*if (isUsingExcel && lastUploadedFile) {
-            processExcelFile(lastUploadedFile); // Reload from last uploaded file
-        } else {
-            loadFile(); // Reload from Airtable
-        }
-        */
-        if (isFilterEmployeeActive){
-            filterAmbatovyEmployees();
-        }
-        else{
-            reloadFullOrgChart();
-        }     
+        updateOrgChartWithNewLevel();
     }
 });
 
 document.getElementById("less-granular").addEventListener("click", () => {
     if (maxLevel > 6) { // Define a lower limit if necessary
         maxLevel--;
-        /*if (isUsingExcel && lastUploadedFile) {
-            processExcelFile(lastUploadedFile); // Reload from last uploaded file
-        } else {
-            loadFile(); // Reload from Airtable
-        }
-        */
-        if (isFilterEmployeeActive){
-            filterAmbatovyEmployees();
-        }
-        else{
-            reloadFullOrgChart();
-        }     
+        updateOrgChartWithNewLevel();
     }
 });
 


### PR DESCRIPTION
## Summary
- in `more-granular` and `less-granular` click handlers, rebuild the chart using `updateOrgChartWithNewLevel()` instead of reloading data
- keep the call to `restoreOriginalView()` in the `more-granular` handler

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_687f3eeb5f8083319120ab849459928c